### PR TITLE
Configurable colors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -31,7 +31,7 @@ class SwacketsView
 
 
     sweatify: ->
-        sweatyness = 0
+        sweatyness = -1
         colors = atom.config.get('swackets.colors')
 
         setTimeout ->

--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -32,7 +32,7 @@ class SwacketsView
 
     sweatify: ->
         sweatyness = 0
-        colors = ['#ff3333', '#ba8cb8', '#8ab7d8', '#60dd60', '#ffff70', '#ea9d70', '#e76464']
+        colors = atom.config.get('swackets.colors')
 
         setTimeout ->
 

--- a/lib/swackets.coffee
+++ b/lib/swackets.coffee
@@ -3,6 +3,13 @@ SwacketsView = require './swackets-view'
 
 module.exports =
 
+  config:
+    colors:
+      default: ['#ff3333', '#ba8cb8', '#8ab7d8', '#60dd60', '#ffff70', '#ea9d70', '#e76464']
+      type: 'array'
+      items:
+        type: 'string'
+
   areaView: null
 
   activate: (state) ->


### PR DESCRIPTION
I use a solarized light theme and the default colors for swackets can be difficult to see on the light yellowish background color.

![screen shot 2015-10-08 at 12 48 40 pm](https://cloud.githubusercontent.com/assets/1903876/10375869/6271f026-6dc0-11e5-9adf-246fbba35221.png)

This PR is to make the colors array configurable. I also noticed that the first color in the list of colors was being skipped over and never used due to the computation of the initial `sweatyness` value so I fixed that by offsetting the initial value by `-1`.