### PR TITLE
Refactor for big speed improvements

### DIFF
--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -43,14 +43,20 @@ class SwacketsView
         lines.style.display = 'none'
         config = @config()
 
-        lineGroups = @queryToArray document.querySelectorAll('atom-text-editor.is-focused::shadow .lines > div:not(.cursors) > div:not(.icon-right)')
+        lineGroups = @lineGroupsQueryToArray document.querySelectorAll('atom-text-editor.is-focused::shadow .lines > div:not(.cursors) > div:not(.icon-right)')
         @sweatifyLineGroups(lineGroups)
 
         lines.style.display = ''
 
-    queryToArray: (query) ->
+    lineGroupsQueryToArray: (query) ->
         arr = []
         for item in query
+            # Sometimes, Atom keeps one of the lineGroups with a single line children,
+            # which we need to ignore. For example, when we scroll to the line 192, Atom
+            # may still have a lineGroup with the greatest zIndex with only line 60.
+            # This mess up our calculation for which line is the fist one on the screen so
+            # we can calculate the initial openBracketsOffset
+            continue if item.children.length == 2 and +item.children[1].dataset.screenRow > 0
             arr.push item
         arr
 
@@ -59,7 +65,7 @@ class SwacketsView
             Math.min(1, Math.max(-1, b.style.zIndex - a.style.zIndex))
 
         firstLine = sortedLineGroups[0].querySelector('.line')
-        openBrackets = @openBracketsOffsetFor(+firstLine.getAttribute('data-screen-row'))
+        openBrackets = @openBracketsOffsetFor(+firstLine.dataset.screenRow)
 
         sortedLineGroups.forEach (lineGroup) =>
             spans = lineGroup.querySelectorAll('span:not(.comment)')

--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -30,10 +30,12 @@ class SwacketsView
     sweatify: ->
         if (atom.config.get('swackets.syntax') == 'Brackets')
             openSyntax = '{'
-            regex = /^.*?([\{\}])$/
+            closeSyntax = '}'
+            regex = /^.*?([\{\}]+)$/
         else
             openSyntax = '('
-            regex = /^.*?([\(\)])$/
+            closeSyntax = ')'
+            regex = /^.*?([\(\)]+)$/
 
         setTimeout ->
             lines = document.querySelector("atom-text-editor.is-focused::shadow .lines")
@@ -52,7 +54,7 @@ class SwacketsView
                   openBrackets++
                   if openBrackets > 11
                     openBrackets = 0
-                else
+                else if match[1] == closeSyntax
                   openBrackets--
                   if openBrackets < 0
                     openBrackets = 11

--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -1,4 +1,4 @@
-{CompositeDisposable} = require 'atom'
+{Range, Point, CompositeDisposable} = require 'atom'
 
 module.exports =
 class SwacketsView
@@ -6,6 +6,7 @@ class SwacketsView
     intervalID = null
     openBrackets = 0
     config = {}
+    totalColors = 11
 
     constructor: ->
         @sweatifyTimeout()
@@ -40,26 +41,48 @@ class SwacketsView
         lines = document.querySelector('atom-text-editor.is-focused::shadow .lines')
         return if !lines
         lines.style.display = 'none'
-        openBrackets = 0
         config = @config()
 
-        lineGroups = document.querySelectorAll('atom-text-editor.is-focused::shadow .lines > div:not(.cursors) > div')
+        lineGroups = @queryToArray document.querySelectorAll('atom-text-editor.is-focused::shadow .lines > div:not(.cursors) > div:not(.icon-right)')
         @sweatifyLineGroups(lineGroups)
 
         lines.style.display = ''
 
-    sweatifyLineGroups: (lineGroups) ->
-        sortedLineGroups = Array.prototype.sort.call lineGroups, (a, b) =>
-            Math.min(1, Math.max(-1, a.style.zIndex - b.style.zIndex))
+    queryToArray: (query) ->
+        arr = []
+        for item in query
+            arr.push item
+        arr
 
-        Array.prototype.forEach.call sortedLineGroups, (lineGroup) =>
+    sweatifyLineGroups: (lineGroups) ->
+        sortedLineGroups = lineGroups.sort (a, b) =>
+            Math.min(1, Math.max(-1, b.style.zIndex - a.style.zIndex))
+
+        firstLine = sortedLineGroups[0].querySelector('.line')
+        openBrackets = @openBracketsOffsetFor(+firstLine.getAttribute('data-screen-row'))
+
+        sortedLineGroups.forEach (lineGroup) =>
             spans = lineGroup.querySelectorAll('span:not(.comment)')
             @sweatifySpans(spans)
+
+    openBracketsOffsetFor: (lineNumber) ->
+        {openSyntax, closeSyntax} = config
+
+        range = new Range(new Point(0, 0), new Point(lineNumber, 0))
+        editor = atom.workspace.getActiveTextEditor()
+        return 0 unless editor
+        text = editor.getTextInBufferRange(range)
+
+        openBracketsOffset = 0
+        openBracketsOffset += text.match(new RegExp('\\' + openSyntax, 'g'))?.length || 0
+        openBracketsOffset -= text.match(new RegExp('\\' + closeSyntax, 'g'))?.length || 0
+
+        return Math.max(0, openBracketsOffset % 11)
 
     sweatifySpans: (spans) ->
         {regex} = config
 
-        Array.prototype.forEach.call spans, (span) =>
+        for span in spans
             match = span.innerHTML.match(regex)
             @sweatifySpan(span, match) if match
 
@@ -69,12 +92,12 @@ class SwacketsView
         color = openBrackets
         if match[1] == openSyntax
             openBrackets++
-            if openBrackets > 11
+            if openBrackets > totalColors
                 openBrackets = 0
         else if match[1] == closeSyntax
             openBrackets--
             if openBrackets < 0
-                openBrackets = 11
+                openBrackets = totalColors
             color = openBrackets
         className = ' swackets-' + color
         span.className = span.className.replace(/( swackets-\d+|$)/, className)

--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -38,30 +38,37 @@ class SwacketsView
             regex = /^.*?([\(\)]+)$/
 
         setTimeout ->
-            lines = document.querySelector("atom-text-editor.is-focused::shadow .lines")
+            lines = document.querySelector('atom-text-editor.is-focused::shadow .lines')
             return if !lines
             lines.style.display = 'none'
 
             openBrackets = 0
 
-            spans = document.querySelectorAll("atom-text-editor.is-focused::shadow .lines span")
+            lineGroups = document.querySelectorAll('atom-text-editor.is-focused::shadow .lines > div:not(.cursors) > div')
 
-            for span in spans
-              match = span.innerHTML.match(regex)
-              if match and span.className.indexOf('comment') < 0
-                color = openBrackets
-                if match[1] == openSyntax
-                  openBrackets++
-                  if openBrackets > 11
-                    openBrackets = 0
-                else if match[1] == closeSyntax
-                  openBrackets--
-                  if openBrackets < 0
-                    openBrackets = 11
+            sortedLineGroups = Array.prototype.sort.call lineGroups, (a, b) ->
+              Math.min(1, Math.max(-1, a.style.zIndex - b.style.zIndex))
+
+            Array.prototype.forEach.call sortedLineGroups, (lineGroup) ->
+              spans = lineGroup.querySelectorAll('span:not(.comment)')
+
+              Array.prototype.forEach.call spans, (span) ->
+                match = span.innerHTML.match(regex)
+                if match
                   color = openBrackets
+                  if match[1] == openSyntax
+                    openBrackets++
+                    if openBrackets > 11
+                      openBrackets = 0
+                  else if match[1] == closeSyntax
+                    openBrackets--
+                    if openBrackets < 0
+                      openBrackets = 11
+                    color = openBrackets
 
-                className = ' swackets-' + color
-                span.className = span.className.replace(/( swackets-\d+|$)/, className)
+                  className = ' swackets-' + color
+                  span.className = span.className.replace(/( swackets-\d+|$)/, className)
+
 
             lines.style.display = ''
         , 16

--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -4,71 +4,77 @@ module.exports =
 class SwacketsView
 
     intervalID = null
+    openBrackets = 0
+    config = {}
 
     constructor: ->
-        @sweatify()
+        @sweatifyTimeout()
 
         @subscriptions = new CompositeDisposable
         @subscriptions.add atom.workspace.onDidChangeActivePaneItem =>
-            @sweatify()
+            @sweatifyTimeout()
             editor = atom.workspace.getActiveTextEditor()
             return unless editor
-            @subscriptions.add editor.onDidChange(@sweatify)
+            @subscriptions.add editor.onDidChange(@sweatifyTimeout)
 
-        intervalID = setInterval =>
-            @sweatify()
-        , 140 #onScroll better in some cases, worse when scrolling
+        intervalID = setInterval @sweatifyTimeout, 140 #onScroll better in some cases, worse when scrolling
 
         editor = atom.workspace.getActiveTextEditor()
         return unless editor
-        @subscriptions.add editor.onDidChange(@sweatify)
+        @subscriptions.add editor.onDidChange(@sweatifyTimeout)
 
     destroy: ->
         clearInterval(intervalID)
         @subscriptions.dispose()
 
-    sweatify: ->
+    config: ->
         if (atom.config.get('swackets.syntax') == 'Brackets')
-            openSyntax = '{'
-            closeSyntax = '}'
-            regex = /^.*?([\{\}]+)$/
+            return {openSyntax: '{', closeSyntax: '}', regex: /^.*?([\{\}]+)$/}
         else
-            openSyntax = '('
-            closeSyntax = ')'
-            regex = /^.*?([\(\)]+)$/
+            return {openSyntax: '(', closeSyntax: ')', regex: /^.*?([\(\)]+)$/}
 
-        setTimeout ->
-            lines = document.querySelector('atom-text-editor.is-focused::shadow .lines')
-            return if !lines
-            lines.style.display = 'none'
+    sweatifyTimeout: =>
+        setTimeout @sweatify, 16
 
-            openBrackets = 0
+    sweatify: =>
+        lines = document.querySelector('atom-text-editor.is-focused::shadow .lines')
+        return if !lines
+        lines.style.display = 'none'
+        openBrackets = 0
+        config = @config()
 
-            lineGroups = document.querySelectorAll('atom-text-editor.is-focused::shadow .lines > div:not(.cursors) > div')
+        lineGroups = document.querySelectorAll('atom-text-editor.is-focused::shadow .lines > div:not(.cursors) > div')
+        @sweatifyLineGroups(lineGroups)
 
-            sortedLineGroups = Array.prototype.sort.call lineGroups, (a, b) ->
-              Math.min(1, Math.max(-1, a.style.zIndex - b.style.zIndex))
+        lines.style.display = ''
 
-            Array.prototype.forEach.call sortedLineGroups, (lineGroup) ->
-              spans = lineGroup.querySelectorAll('span:not(.comment)')
+    sweatifyLineGroups: (lineGroups) ->
+        sortedLineGroups = Array.prototype.sort.call lineGroups, (a, b) =>
+            Math.min(1, Math.max(-1, a.style.zIndex - b.style.zIndex))
 
-              Array.prototype.forEach.call spans, (span) ->
-                match = span.innerHTML.match(regex)
-                if match
-                  color = openBrackets
-                  if match[1] == openSyntax
-                    openBrackets++
-                    if openBrackets > 11
-                      openBrackets = 0
-                  else if match[1] == closeSyntax
-                    openBrackets--
-                    if openBrackets < 0
-                      openBrackets = 11
-                    color = openBrackets
+        Array.prototype.forEach.call sortedLineGroups, (lineGroup) =>
+            spans = lineGroup.querySelectorAll('span:not(.comment)')
+            @sweatifySpans(spans)
 
-                  className = ' swackets-' + color
-                  span.className = span.className.replace(/( swackets-\d+|$)/, className)
+    sweatifySpans: (spans) ->
+        {regex} = config
 
+        Array.prototype.forEach.call spans, (span) =>
+            match = span.innerHTML.match(regex)
+            @sweatifySpan(span, match) if match
 
-            lines.style.display = ''
-        , 16
+    sweatifySpan: (span, match) ->
+        {openSyntax, closeSyntax} = config
+
+        color = openBrackets
+        if match[1] == openSyntax
+            openBrackets++
+            if openBrackets > 11
+                openBrackets = 0
+        else if match[1] == closeSyntax
+            openBrackets--
+            if openBrackets < 0
+                openBrackets = 11
+            color = openBrackets
+        className = ' swackets-' + color
+        span.className = span.className.replace(/( swackets-\d+|$)/, className)

--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -96,11 +96,11 @@ class SwacketsView
         {openSyntax, closeSyntax} = config
 
         color = openBrackets
-        if match[1] == openSyntax
+        if match[0].indexOf(openSyntax) >= 0 and match[0].indexOf(closeSyntax) < 0
             openBrackets++
             if openBrackets > totalColors
                 openBrackets = 0
-        else if match[1] == closeSyntax
+        else if match[0].indexOf(closeSyntax) >= 0 and match[0].indexOf(openSyntax) < 0
             openBrackets--
             if openBrackets < 0
                 openBrackets = totalColors

--- a/lib/swackets.coffee
+++ b/lib/swackets.coffee
@@ -6,15 +6,7 @@ module.exports =
   config:
     colors:
         title: 'Syntax Colours To Use:'
-        default: ['#9c5e99', '#8ab7d8', '#60dd60', '#ffff70', '#ea9d70', '#971717']
-        type: 'array'
-        items:
-            type: 'string'
-
-    colors2:
-        title: 'Syntax Colours To Alternate:'
-        description: '[**SIMILAR** colours to first set to differentiate equally nested syntax]'
-        default: ['#f3a0f2', '#3c81b3', '#478a03', '#afaf00', '#b7761d', '#d82121']
+        default: ['#AAA', '#0F0', '#0FA', '#86F', '#F0F', '#93F']
         type: 'array'
         items:
             type: 'string'

--- a/styles/swackets.less
+++ b/styles/swackets.less
@@ -8,4 +8,16 @@
     pointer-events: none;
     z-index: -1;
   }
+  .swackets-0 {color: #aaa;}
+  .swackets-1 {color: #0f0;}
+  .swackets-2 {color: #00ff7f;}
+  .swackets-3 {color: #00ffff;}
+  .swackets-4 {color: #836FFF;}
+  .swackets-5 {color: #FF00FF;}
+  .swackets-6 {color: #9B30FF;}
+  .swackets-7 {color: #00ff7f;}
+  .swackets-8 {color: #00ffff;}
+  .swackets-9 {color: #836FFF;}
+  .swackets-10 {color: #FF00FF;}
+  .swackets-11 {color: #9B30FF;}
 }

--- a/styles/swackets.less
+++ b/styles/swackets.less
@@ -8,16 +8,4 @@
     pointer-events: none;
     z-index: -1;
   }
-  .swackets-0 {color: #aaa;}
-  .swackets-1 {color: #0f0;}
-  .swackets-2 {color: #00ff7f;}
-  .swackets-3 {color: #00ffff;}
-  .swackets-4 {color: #836FFF;}
-  .swackets-5 {color: #FF00FF;}
-  .swackets-6 {color: #9B30FF;}
-  .swackets-7 {color: #00ff7f;}
-  .swackets-8 {color: #00ffff;}
-  .swackets-9 {color: #836FFF;}
-  .swackets-10 {color: #FF00FF;}
-  .swackets-11 {color: #9B30FF;}
 }


### PR DESCRIPTION
Hello,

So, I loved swackets, but it is very slow, leading me to often have to disable it to use atom.
Then I thought of different ways of colouring the elements, first idea was this one:

https://jsfiddle.net/ty6uhmy1/1/

Instead of making a lot of calls to the DOM, which is slow, I'd just replace all of it at once. But this doesn't work in atom, because it tracks those dom nodes, if we replace them, the editor pane freezes.

So, I had to still iterate through each DOM element and mutate them, but with the help of [letitalew ideas](http://blog.letitialew.com/post/30425074101/repaints-and-reflows-manipulating-the-dom), I did somethings to make it as efficient as possible:

- Hide the `.lines` element with `display = 'none'` and unhide it after changing all the other elements, this way we will only have one repaint
- Add CSS classes instead of inline styles, this is much faster
- Removed jQuery, it's unecesary and slow
- Now there's only a single loop in the code
- It uses regexes to try to match text instead of iterating child elements or something

Here's a jsfiddle with those ideas:

https://jsfiddle.net/ty6uhmy1/3/

I haven't done any benchmarks, but it looks much faster for me as I code, I don't have to disable it anymore.

But there is still a problem, the colors are now on the stylesheet, so how can we make it configurable?

By the way, I stole the colors from the [lighttable rainbow plugin](https://github.com/LightTable/Rainbow), I don't know if there is a default color pallete for those plugins across code editors, but I believe there should be.

![captura de tela 2015-12-14 as 00 26 37](https://cloud.githubusercontent.com/assets/792201/11771822/a76b8f96-a1fc-11e5-8439-a950c51aaa10.png)

I didn't understood that part of the code about range, point or scroll positions, so I deleted it. It's fast enough so if that was there for performance it might not be needed anymore.

Please let me know if I missed anything!

--- Edit ---

Fixed coloring when having immediate closed parens, like in `something()`