### PR TITLE
Remove unnecessary regex

### DIFF
--- a/lib/swackets-view.coffee
+++ b/lib/swackets-view.coffee
@@ -53,16 +53,12 @@ class SwacketsView
         closeExpr = ('\\' + s for s in close).join('')
         expr = openExpr + closeExpr
 
-        notEscapedModifier = '(?<!\\\\)'
-        bracketModifier = '(?:[$%#].?)?'
-        modifiers = notEscapedModifier + bracketModifier
-
         return {
           openSyntax: open,
           closeSyntax: close,
           regex: new RegExp('^.*?([' + expr + ']+)$'),
-          openRegex: new RegExp(modifiers + '[' + openExpr + ']', 'g'),
-          closeRegex: new RegExp(modifiers + '[' + closeExpr + ']', 'g')
+          openRegex: new RegExp('[' + openExpr + ']', 'g'),
+          closeRegex: new RegExp('[' + closeExpr + ']', 'g')
         }
 
     getSwacketsStylesheet: ->


### PR DESCRIPTION
This fixes #24 

As part of #23, I added some regexes that I thought were required to make escaped brackets (`\{`) and "special" brackets (eg `%r{`), but it turns out that none of that was necessary. All that was necessary was changing `sweatifySpan` to use the regexes created above, rather than the arrays.